### PR TITLE
Fixes to compile with latest Castle Game Engine 6.3

### DIFF
--- a/FireMadness.pas
+++ b/FireMadness.pas
@@ -30,7 +30,7 @@ uses  Classes, SysUtils, fgl, CastleLog, {CastleAndroidInternalLog,}
   CastleGLImages, CastleGlUtils,
   castleVectors, castleImages,
   CastleKeysMouse, CastleJoysticks,
-  CastleFreeType, CastleFonts, CastleUnicode, CastleStringUtils,
+  CastleFonts, CastleUnicode, CastleStringUtils,
   Game_controls, general_var, Sound_Music, botsdata,
   map_manager, Translation, GL_button, MyFont;
 

--- a/FireMadness.pas
+++ b/FireMadness.pas
@@ -1561,7 +1561,7 @@ begin
  if Window.Height<MinWindowHeight then Window.Height:=MinWindowHeight;
  RescaleWindow:=true;
  PauseMode:=true;
- window.doRender;
+ window.Invalidate;
 end;
 
 var RenderingBuisy:boolean=false;
@@ -1610,7 +1610,7 @@ end;
 
 procedure doTimer;
 begin
-  window.DoRender;
+  window.Invalidate;
 
   if (musicTimer<now) then doLoadNewMusic;
   if isMusicStart then doStartMusic;

--- a/botsdata.pas
+++ b/botsdata.pas
@@ -6,7 +6,7 @@ interface
 
 uses SysUtils, castleFilesUtils,
      CastleGLImages,
-     CastleOpenAL, CastleSoundEngine, {CastleTimeUtils, }CastleVectors,
+     CastleSoundEngine, {CastleTimeUtils, }CastleVectors,
      Game_controls, general_var,sound_music, map_manager;
 
 const missle_explosion=10;

--- a/gl_button.pas
+++ b/gl_button.pas
@@ -8,7 +8,7 @@ uses
   Classes, SysUtils,
   CastleGLImages, CastleFilesUtils,
   castleVectors, {castleImages,}
-  CastleFreeType, CastleFonts, MyFont, CastleUnicode, CastleStringUtils,
+  CastleFonts, MyFont, CastleUnicode, CastleStringUtils,
   Translation, general_var;
 
 type TSimpleProcedure=procedure;

--- a/sound_music.pas
+++ b/sound_music.pas
@@ -5,7 +5,7 @@ unit Sound_Music;
 interface
 
 uses {$IFDEF UNIX}cthreads,{$ENDIF}sysUtils,Classes, castleFilesUtils,
-  CastleOpenAL, CastleSoundEngine, CastleTimeUtils, CastleVectors,
+  CastleSoundEngine, CastleTimeUtils, CastleVectors,
   general_var;
 
 const SoundExtension={$ifdef Android}'.wav'{$else}'.ogg'{$endif};


### PR DESCRIPTION
As I'm doing some non-trivial API changes in the Castle Game Engine 6.3 (to be released as 6.4), I test the engine on various real-life code using the Castle Game (like your games), to judge how much compatibility did I break :)

I want to minimize the compatibility break as much as possible, and only mark stuff as "deprecated", but it's not (easily) possible for some of the latest changes, so unfortunately some changes in user (game) code will be necessary.

In this case, some unit renames in CGE 6.3 are affecting your code. The affected units can be just removed. 

Also, Window.DoRender is not available, since at least CGE 6.2. We could provide a compatibility "patch" in the engine for it (keep it defined but deprecated), but it was only public for a short time, and it's really a bit dirty -- so I would prefer to just keep it private :) More comments in the commits.

Regards!